### PR TITLE
feature: Script to switch to non-root user during server start

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Create and set permissions for coverage directory
+mkdir -p /app/cov
+chmod 777 /app/cov
+
+# Switch to django-user during server start
+exec su django-user -c "python manage.py wait_for_db && python manage.py runserver 0.0.0.0:8000"


### PR DESCRIPTION
Script switches to non-root user during runtime instead of during docker build time to allow ci/cd environments to run with the necessary permissions