### PR TITLE
Application deploy 2

### DIFF
--- a/app/ansible/deploy.yml
+++ b/app/ansible/deploy.yml
@@ -33,7 +33,7 @@
 
 
     - name: Install required packages
-      dnf:
+      apt:
         name: 
           - docker-ce
           - docker-ce-cli


### PR DESCRIPTION
Ansible erroneously specified dnf as the package manager when installing packages. Initially used dnf, but updated to ubuntu based system. This PR addresses this issue and ansible should now use apt instead of dnf.